### PR TITLE
Add option 'verifypath' to check if the basepath exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A zookeeper server with proper ACLs to a base znode (zookeeper node) is required
 
 If no such server is available, installation can be performed as follows:
 ~~~~bash
-zkversion=3.4.5
+zkversion=3.4.6
 basepath=`mktemp -d` # not permanent, choose other directory as desired
 
 mkdir -p $basepath/zk/server/data

--- a/bin/zkrsync.py
+++ b/bin/zkrsync.py
@@ -242,6 +242,7 @@ def main():
         'checksum'    : ('run rsync with --checksum', None, 'store_true', False),
         'hardlinks'   : ('run rsync with --hard-links', None, 'store_true', False),
         # Individual client options
+        'verifypath'  : ('Check basepath exists while running', None, 'store_false', True),
         'daemon'      : ('daemonize client', None, 'store_true', False),
         'domain'      : ('substitute domain', None, 'store', None),
         'logfile'     : ('Output to logfile', None, 'store', '/tmp/zkrsync/%(session)s-%(rstype)s-%(pid)s.log'),
@@ -268,6 +269,7 @@ def main():
         'auth_data'   : acreds,
         'rsyncpath'   : go.options.rsyncpath,
         'netcat'      : go.options.netcat,
+        'verifypath'  : go.options.verifypath,
         }
 
     if go.options.daemon:

--- a/bin/zkrsync.py
+++ b/bin/zkrsync.py
@@ -111,6 +111,8 @@ def do_pathsonly(options, kwargs):
     kwargs['rsyncdepth'] = options.depth
     kwargs['excludere'] = options.excludere
     kwargs['excl_usr'] = options.excl_usr
+    kwargs['rsubpaths'] = options.rsubpaths
+
     rsyncP = RsyncSource(options.servers, **kwargs)
     locked = rsyncP.acq_lock()
     if locked:
@@ -144,6 +146,7 @@ def start_destination(options, kwargs):
 def start_source(options, kwargs):
     """ Start a rsync source"""
     kwargs['rsyncdepth'] = options.depth
+    kwargs['rsubpaths'] = options.rsubpaths
     kwargs['arbitopts'] = options.arbitopts
     kwargs['checksum'] = options.checksum
     kwargs['dryrun'] = options.dryrun
@@ -234,6 +237,7 @@ def main():
         'dryrun'      : ('run rsync in dry run mode', None, 'store_true', False, 'n'),
         'rsyncpath'   : ('rsync basepath', None, 'store', None, 'r'),  # May differ between sources and dests
         # Pathbuilding (Source clients and pathsonly ) specific options:
+        'rsubpaths'   : ('rsync subpaths', 'strlist', 'store', None),
         'excludere'   : ('Exclude from pathbuilding', None, 'regex', re.compile('/\.snapshots(/.*|$)')),
         'excl_usr'    : ('If set, exclude paths for this user only when using excludere', None, 'store', 'root'),
         'depth'       : ('queue depth', "int", 'store', 3),

--- a/bin/zkrsync.py
+++ b/bin/zkrsync.py
@@ -237,7 +237,7 @@ def main():
         'dryrun'      : ('run rsync in dry run mode', None, 'store_true', False, 'n'),
         'rsyncpath'   : ('rsync basepath', None, 'store', None, 'r'),  # May differ between sources and dests
         # Pathbuilding (Source clients and pathsonly ) specific options:
-        'rsubpaths'   : ('rsync subpaths', 'strlist', 'store', None),
+        'rsubpaths'   : ('rsync subpaths, specified as <depth>_<path>, with deepest paths last', 'strlist', 'store', None),
         'excludere'   : ('Exclude from pathbuilding', None, 'regex', re.compile('/\.snapshots(/.*|$)')),
         'excl_usr'    : ('If set, exclude paths for this user only when using excludere', None, 'store', 'root'),
         'depth'       : ('queue depth', "int", 'store', 3),

--- a/lib/vsc/zk/base.py
+++ b/lib/vsc/zk/base.py
@@ -162,7 +162,7 @@ class VscKazooClient(KazooClient):
 
     def set_znode(self, znode=None, value=''):
         znode_path = self.znode_path(znode)
-        return self.set(znode_path, value)
+        return self.set(znode_path, str(value))
 
     def get_znode(self, znode=None):
         znode_path = self.znode_path(znode)

--- a/lib/vsc/zk/depthwalk.py
+++ b/lib/vsc/zk/depthwalk.py
@@ -113,6 +113,7 @@ def get_pathlist(path, depth, exclude_re=None, exclude_usr=None, rsubpaths=[]):
     Recursive is True if and only if it is exactly on the depth specified.
     Exclude_re is a regex to exclude, if it belongs to exclude_usr. (used for eg. excluding snapshot folders) 
     if subpaths are given with rsubpaths, these are also walked with the given depth, and merged into the list
+    Subpaths should already be in the base path pathlist.
     """
 
     pathlist = build_paths(path, depth, exclude_re, exclude_usr)
@@ -126,7 +127,7 @@ def get_pathlist(path, depth, exclude_re=None, exclude_usr=None, rsubpaths=[]):
                 logger.raiseException('%s is not in the pathlist of %s with depth %d!' % (subpath, path, depth))
             else:
                 sublist = build_paths(subpath, depth, exclude_re, exclude_usr)
-                pathdict.update(sublist)
+                pathdict.update(sublist)  # This suffice because the subpath is always in the pathlist
 
         pathlist = pathdict.items()
 

--- a/lib/vsc/zk/rsync/source.py
+++ b/lib/vsc/zk/rsync/source.py
@@ -391,6 +391,10 @@ class RsyncSource(RsyncController):
         return self.dest_state(dest, self.STATUS)
 
     def handle_dest_state(self, dest, destpath, current_state):
+        """ 
+        Disable destination by consuming it from queue when paused and return false
+        If destination is active, return true
+        """
         if current_state == self.STATE_PAUSED:
             self.set_znode(destpath, self.STATE_DISABLED)
             self.dest_queue.consume()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-zk',
-    'version': '0.8.0',
+    'version': '0.8.1',
     'author': [sdw],
     'maintainer': [sdw, kw],
     'packages': ['vsc', 'vsc.zk', 'vsc.zk.rsync'],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-zk',
-    'version': '0.7.4',
+    'version': '0.8.0',
     'author': [sdw],
     'maintainer': [sdw, kw],
     'packages': ['vsc', 'vsc.zk', 'vsc.zk.rsync'],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ shared_setup.SHARED_TARGET.update({
 
 PACKAGE = {
     'name': 'vsc-zk',
-    'version': '0.8.1',
+    'version': '0.8.2',
     'author': [sdw],
     'maintainer': [sdw, kw],
     'packages': ['vsc', 'vsc.zk', 'vsc.zk.rsync'],

--- a/test/depthwalk.py
+++ b/test/depthwalk.py
@@ -93,19 +93,32 @@ class DepthWalkTest(TestCase):
                ('/tree/b1/ba2', 0), ('/tree/a1/ac2', 0), ('/tree/a1/ab2', 0), ('/tree/a1/aa2', 0),
                ('/tree/a1/ab2/aa3', 0), ('/tree/a1/ab2/aa3/sub1', 0), ('/tree/a1/ab2/aa3/sub2', 0),
                ('/tree/a1/ab2/aa3/sub2/sub21', 0), ('/tree/a1/ab2/aa3/sub2/sub21/sub211', 1), ]
-        subpath1 = 'a1/ab2/aa3'
-        subpath2 = 'a1/ab2/aa3/sub2'
-        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 3, exclude_re=regex, exclude_usr=None, rsubpaths=['/a1/ab2/aa3'])
-        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 2, exclude_re=regex, exclude_usr=None, rsubpaths=[subpath1])
-        genlist = [(re.sub('/tmp/[^/]+', '/tree', gen), rec) for (gen, rec) in dw.get_pathlist(self.basedir, 3, exclude_re=regex, rsubpaths=[subpath1])]
 
+        subpath1 = '3_a1/ab2/aa3'
+        subpath2 = '3_a1/ab2/aa3/sub2'
+        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 3, exclude_re=regex, exclude_usr=None, rsubpaths=['3_/a1/ab2/aa3'])
+        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 2, exclude_re=regex, exclude_usr=None, rsubpaths=['3_a1/ab2/aa3'])
+        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 3, exclude_re=regex, exclude_usr=None, rsubpaths=['1_a1'])
+
+        genlist = [(re.sub('/tmp/[^/]+', '/tree', gen), rec) for (gen, rec) in dw.get_pathlist(self.basedir, 3, exclude_re=regex, rsubpaths=[subpath1])]
         self.assertListEqual(sorted(genlist), sorted(res))
+
         genlist = [(re.sub('/tmp/[^/]+', '/tree', gen), rec)
                    for (gen, rec) in dw.get_pathlist(self.basedir, 3, exclude_re=regex, rsubpaths=[subpath1, subpath2])]
-
         res.remove(('/tree/a1/ab2/aa3/sub2/sub21/sub211', 1))
         res.extend([('/tree/a1/ab2/aa3/sub2/sub21/sub211', 0), ('/tree/a1/ab2/aa3/sub2/sub21/sub211/sub2112', 1)])
         self.assertListEqual(sorted(genlist), sorted(res))
+
+        subpath2 = '4_a1/ab2/aa3/sub2'
+        genlist = [(re.sub('/tmp/[^/]+', '/tree', gen), rec)
+                   for (gen, rec) in dw.get_pathlist(self.basedir, 3, exclude_re=regex, rsubpaths=[subpath1, subpath2])]
+        res.remove(('/tree/a1/ab2/aa3/sub2/sub21/sub211/sub2112', 1))
+        res.append(('/tree/a1/ab2/aa3/sub2/sub21/sub211/sub2112', 0))
+        self.assertListEqual(sorted(genlist), sorted(res))
+
+        subpath1 = '3_a1/ab2'
+        subpath2 = '3_a1/ab2/aa3'
+        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 3, exclude_re=regex, exclude_usr=None, rsubpaths=[subpath2, subpath1])
 
     def test_encode_paths(self):
         """ Test the encoding of a pathlist """

--- a/test/depthwalk.py
+++ b/test/depthwalk.py
@@ -44,6 +44,10 @@ class DepthWalkTest(TestCase):
         """ Create a test direcory structure """
         self.basedir = tempfile.mkdtemp()
         dirs = ['a1', 'b1', 'c1', 'a1/aa2', 'a1/ab2', 'a1/ac2', 'b1/ba2', 'b1/bb2', 'a1/ab2/aa3']
+        extradirs = ['a1/ab2/aa3/sub1', 'a1/ab2/aa3/sub2', 'a1/ab2/aa3/sub2/sub21',
+                     'a1/ab2/aa3/sub2/sub21/sub211', 'a1/ab2/aa3/sub2/sub21/sub211/sub2112']
+        dirs.extend(extradirs)
+
         for dir in dirs:
             path = '%s/%s' % (self.basedir, dir)
             os.mkdir(path)
@@ -81,6 +85,27 @@ class DepthWalkTest(TestCase):
                ('/tree/a1/ab2/aa3', 1)]
         genlist = [(re.sub('/tmp/[^/]+', '/tree', gen), rec) for (gen, rec) in dw.get_pathlist(self.basedir, 3, exclude_re=regex, exclude_usr=None)]
         self.assertListEqual(genlist , res)
+
+    def test_get_pathlist_with_subpaths(self):
+        """ Tests the functionality of get_pathlist with an exclude rule and subpaths"""
+        regex = re.compile('/\.snapshots(/.*|$)')
+        res = [('/tree', 0), ('/tree/c1', 0), ('/tree/b1', 0), ('/tree/a1', 0), ('/tree/b1/bb2', 0),
+               ('/tree/b1/ba2', 0), ('/tree/a1/ac2', 0), ('/tree/a1/ab2', 0), ('/tree/a1/aa2', 0),
+               ('/tree/a1/ab2/aa3', 0), ('/tree/a1/ab2/aa3/sub1', 0), ('/tree/a1/ab2/aa3/sub2', 0),
+               ('/tree/a1/ab2/aa3/sub2/sub21', 0), ('/tree/a1/ab2/aa3/sub2/sub21/sub211', 1), ]
+        subpath1 = 'a1/ab2/aa3'
+        subpath2 = 'a1/ab2/aa3/sub2'
+        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 3, exclude_re=regex, exclude_usr=None, rsubpaths=['/a1/ab2/aa3'])
+        self.assertRaises(Exception, dw.get_pathlist, self.basedir, 2, exclude_re=regex, exclude_usr=None, rsubpaths=[subpath1])
+        genlist = [(re.sub('/tmp/[^/]+', '/tree', gen), rec) for (gen, rec) in dw.get_pathlist(self.basedir, 3, exclude_re=regex, rsubpaths=[subpath1])]
+
+        self.assertListEqual(sorted(genlist), sorted(res))
+        genlist = [(re.sub('/tmp/[^/]+', '/tree', gen), rec)
+                   for (gen, rec) in dw.get_pathlist(self.basedir, 3, exclude_re=regex, rsubpaths=[subpath1, subpath2])]
+
+        res.remove(('/tree/a1/ab2/aa3/sub2/sub21/sub211', 1))
+        res.extend([('/tree/a1/ab2/aa3/sub2/sub21/sub211', 0), ('/tree/a1/ab2/aa3/sub2/sub21/sub211/sub2112', 1)])
+        self.assertListEqual(sorted(genlist), sorted(res))
 
     def test_encode_paths(self):
         """ Test the encoding of a pathlist """

--- a/test/mock.py
+++ b/test/mock.py
@@ -32,13 +32,42 @@ class KazooClient(object):
 
     BASE_ZNODE = '/admin'
 
+
     def __init__(self, hosts, auth_data=None, default_acl=None):
-        pass
+        self.objs = {}
+        self.whoami = 'test'
 
     def start(self):
         pass
 
     def ensure_path(self, path):
+        pass
+
+    def set(self, obj, value):
+        self.objs[obj] = value;
+
+    def create(self, obj, value, **kw):
+        return self.set(obj, value)
+
+    def get(self, obj):
+        return (self.objs[obj], 'dummy')
+
+    def exists(self, obj):
+        return obj in self.objs
+
+    def Lock(self, path, id):
+        return Lock(self)
+        pass
+
+    def print_objs(self):
+        print  self.objs
+
+class Lock(object):
+    def __init__(self, dummy1):
+        pass
+    def __exit__(self, bl, er, erb):
+        pass
+    def __enter__(self):
         pass
 
 class Party(object):
@@ -52,6 +81,8 @@ class LockingQueue(object):
     def __init__(self, thingy, name, **kwargs):
         pass
     def put(self, something):
+        pass
+    def consume(self):
         pass
 
 class Counter(object):

--- a/test/zkclient.py
+++ b/test/zkclient.py
@@ -99,6 +99,32 @@ class zkClientTest(TestCase):
         filec = open(filen, "r").read()
         self.assertMultiLineEqual(filec, res)
 
+    def test_activate_and_pausing_dests(self):
+        """ Test the pausing , disabling and activation of destinations """
+        zkclient = RsyncDestination('dummy', rsyncpath='/tmp', session='new')
+        zkclient.pause()
+        val, dum = zkclient.get('/admin/rsync/new/dests/test')
+        self.assertEqual(val, '')
+        zkclient.activate()
+        val, dum = zkclient.get('/admin/rsync/new/dests/test')
+        self.assertEqual(val, 'active')
+        zkclient.pause()
+        val, dum = zkclient.get('/admin/rsync/new/dests/test')
+        self.assertEqual(val, 'paused')
+
+        zkclient = RsyncSource('dummy', session='new', netcat=True, rsyncpath='/path/dummy', rsyncdepth=2)
+        self.assertFalse(zkclient.dest_is_sane('test'))
+        val, dum = zkclient.get('/admin/rsync/new/dests/test')
+        self.assertEqual(val, '')
+        zkclient.set('/admin/rsync/new/dests/test', 'active')
+        self.assertTrue(zkclient.dest_is_sane('test'))
+        val, dum = zkclient.get('/admin/rsync/new/dests/test')
+        self.assertEqual(val, 'active')
+        zkclient.set('/admin/rsync/new/dests/test', 'paused')
+        self.assertFalse(zkclient.dest_is_sane('test'))
+        val, dum = zkclient.get('/admin/rsync/new/dests/test')
+        self.assertEqual(val, 'disabled')
+
 def suite():
      """ returns all the testcases in this module """
      return TestLoader().loadTestsFromTestCase(zkClientTest)
@@ -133,7 +159,22 @@ if __name__ == '__main__':
 #     print zkclient.module
 #     print zkclient.watchpath
 
+
 #     zkclient = RsyncDestination('dummy', rsyncpath='/tmp', session='new')
-#     filen = zkclient.generate_daemon_config()
-#     filec = open(filen, "r").read()
-#     print filec
+#     zkclient.pause()
+#     print zkclient.get('/admin/rsync/new/dests/test')
+#     zkclient.activate()
+#     print zkclient.get('/admin/rsync/new/dests/test')
+#     zkclient.pause()
+#     print zkclient.get('/admin/rsync/new/dests/test')
+#
+#     zkclient = RsyncSource('dummy', session='new', netcat=True, rsyncpath='/path/dummy', rsyncdepth=2)
+#     print zkclient.dest_is_sane('test')
+#     print zkclient.get('/admin/rsync/new/dests/test')
+#     zkclient.set('/admin/rsync/new/dests/test', 'active')
+#     print zkclient.dest_is_sane('test')
+#     print zkclient.get('/admin/rsync/new/dests/test')
+#     zkclient.set('/admin/rsync/new/dests/test', 'paused')
+#     print zkclient.dest_is_sane('test')
+#     print zkclient.get('/admin/rsync/new/dests/test')
+


### PR DESCRIPTION
adding option 'verifypath' for both source and destination clients. The clients will check the path regularly, and pause themselves when they are not healthy. 