### PR TITLE
bump version, 9.6 running wo changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kw, sdw
 
 PACKAGE = {
-    'version': '0.9.6',
+    'version': '0.9.7',
     'author': [sdw, kw],
     'maintainer': [sdw, kw],
     'install_requires': [


### PR DESCRIPTION
we have 0.9.6 running, but has been changed w/o versionbump